### PR TITLE
Updated to elements 1.2.0

### DIFF
--- a/src/main/webapp/view.jsp
+++ b/src/main/webapp/view.jsp
@@ -20,8 +20,8 @@
 
 <portlet:defineObjects />
 
-<script src="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/webcomponentsjs/webcomponents-lite.min.js"></script>
-<link href="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/vaadin-elements/vaadin-elements.html" rel="import">
+<script src="https://cdn.vaadin.com/vaadin-elements/1.2.0/webcomponentsjs/webcomponents-lite.min.js"></script>
+<link href="https://cdn.vaadin.com/vaadin-elements/1.2.0/vaadin-grid/vaadin-grid.html" rel="import">
 
 <vaadin-grid selection-mode="multi">
     <table>


### PR DESCRIPTION
```0.3.0-beta12``` no more available on CDN cause 404: we have to fix with current working release of Elements; I realize that now we have to import vaadin-grid/vaadin-grid.html instead of  vaadin-elements.html

proposed patch: 
```
From 11bdf78864f4d74ba900f6a6da77085aa224ceaf Mon Sep 17 00:00:00 2001
From: Franco Rondini 
Date: Sun, 5 Nov 2017 17:51:47 +0100
Subject: [PATCH] Updated to elements 1.2.0

---
 src/main/webapp/view.jsp | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/src/main/webapp/view.jsp b/src/main/webapp/view.jsp
index ffb5939..3912adb 100644
--- a/src/main/webapp/view.jsp
+++ b/src/main/webapp/view.jsp
@@ -20,8 +20,8 @@
 
 <portlet:defineObjects />
 
-<script src="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/webcomponentsjs/webcomponents-lite.min.js"></script>
-<link href="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/vaadin-elements/vaadin-elements.html" rel="import">
+<script src="https://cdn.vaadin.com/vaadin-elements/1.2.0/webcomponentsjs/webcomponents-lite.min.js"></script>
+<link href="https://cdn.vaadin.com/vaadin-elements/1.2.0/vaadin-grid/vaadin-grid.html" rel="import">
 
 <vaadin-grid selection-mode="multi">
     <table>
-- 
2.13.5 (Apple Git-94)
```